### PR TITLE
Allow for different index names

### DIFF
--- a/autofeatselect/auto_feat_select.py
+++ b/autofeatselect/auto_feat_select.py
@@ -169,7 +169,7 @@ class CorrelationCalculator:
         
         # Melt the DataFrame to convert it to long format
         corr_matrix = corr_matrix.reset_index()
-        melted_df = pd.melt(corr_matrix, id_vars='index', value_vars=corr_matrix.columns[1:], var_name='j')
+        melted_df = pd.melt(corr_matrix, id_vars=corr_matrix.columns.name, value_vars=corr_matrix.columns[1:], var_name='j')
         
         # Rename columns for clarity
         melted_df.columns = ['i', 'j', 'correlation_score']


### PR DESCRIPTION
Hi, 
thanks for making the AutoFeatSelect package! 
I noticed that the pd.melt function would throw a key error if my the name of my columns was not 'index'. I think my fix should work by just getting the name from the previously built correlation matrix and allow for flexible naming of the index. 
Hope this works for you as well, have a great day!